### PR TITLE
Update AmazonOrderItemCode Length in XSD

### DIFF
--- a/examples/xsd/amzn-base.xsd
+++ b/examples/xsd/amzn-base.xsd
@@ -628,7 +628,7 @@
 	<xsd:element name="AmazonOrderItemCode">
 		<xsd:simpleType>
 			<xsd:restriction base="xsd:string">
-				<xsd:pattern value="\d{14}"/>
+				<xsd:pattern value="\d{15}"/>
 			</xsd:restriction>
 		</xsd:simpleType>
 	</xsd:element>


### PR DESCRIPTION
This update modifies the length of the AmazonOrderItemCode in the XSD file to accommodate new IDs. The change extends the pattern restriction from 14 to 15 digits.

Changes:

Updated AmazonOrderItemCode pattern restriction from \d{14} to \d{15}.

Reason:
The length of Amazon order item codes has increased from 14 to 15 digits, necessitating this update to ensure proper validation and processing of the new IDs.

Impact:
This change is critical for maintaining compatibility with the new Amazon order item code format. It ensures that the application can correctly handle and validate the updated 15-digit codes.

Testing:

Ensure that XSD validation passes with 15-digit Amazon order item codes. Verify that the application processes the new format correctly. Please review and merge this change to support the new Amazon order item code length.